### PR TITLE
Sets selectedTeam to same team on update

### DIFF
--- a/LitExplore/Client/Teams/TeamCustomisation.razor
+++ b/LitExplore/Client/Teams/TeamCustomisation.razor
@@ -198,9 +198,12 @@
       //The purpose of the next three lines is simply to refresh our UI, we know that HTTP calls shouldn't be overused and this is an easy fix.
       CurrentUser.teams.RemoveAll(t => t.Id == team.Id);
       var value = await Http.GetFromJsonAsync<TeamDTO>($"api/Team/{team.Id}");
-      if (value != null) CurrentUser.teams.Add(value);
+      if (value != null) 
+      {
+        CurrentUser.teams.Add(value);
+        CurrentUser.selectedTeam = value;
+      }
       
-      CurrentUser.selectedTeam = null;
       await refreshGraph.InvokeAsync();
       StateHasChanged();
     }


### PR DESCRIPTION
Min egen lille fejl fra en PR jeg havde i går. Havde ikke set, at hvis man opdaterede et team, så overskrev den selected team med null, hvilket den jo ikke skal.